### PR TITLE
Configure Dependabot to ignore major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,10 @@ version: 2
 updates:
 - package-ecosystem: docker
   directory: /
+  versioning-strategy: increase 
   schedule:
     interval: daily
     timezone: America/Halifax
-  ignore:
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
 - package-ecosystem: maven
   directory: /
   schedule:
@@ -40,12 +38,10 @@ updates:
 - package-ecosystem: docker
   target-branch: v1.3
   directory: /
+  versioning-strategy: increase 
   schedule:
     interval: daily
     timezone: America/Halifax
-  ignore:
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
 - package-ecosystem: maven
   target-branch: v1.3
   directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
   schedule:
     interval: daily
     timezone: America/Halifax
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major"]
 - package-ecosystem: maven
   directory: /
   schedule:
@@ -40,6 +43,9 @@ updates:
   schedule:
     interval: daily
     timezone: America/Halifax
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-major"]
 - package-ecosystem: maven
   target-branch: v1.3
   directory: /


### PR DESCRIPTION
Added ignore rules for major version updates across all dependencies.