### PR TITLE
Spring v4.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<start-class>jasper.JasperApplication</start-class>
 		<argLine>-Djava.security.egd=file:/dev/./urandom -Xmx256m</argLine>
 		<resource.delimiter>@</resource.delimiter>
-		<spring-boot.version>4.0.6</spring-boot.version>
+		<spring-boot.version>4.0.7</spring-boot.version>
 		<spring-cloud.version>2025.1.1</spring-cloud.version>
 		<lombok.version>1.18.46</lombok.version>
 		<testcontainers.version>2.0.5</testcontainers.version>
@@ -26,7 +26,7 @@
 		<jackson-databind-nullable.version>0.2.10</jackson-databind-nullable.version>
 		<postgresql.version>42.7.11</postgresql.version>
 		<sqlite-jdbc.version>3.53.2.0</sqlite-jdbc.version>
-		<hibernate-jpamodelgen.version>7.2.12.Final</hibernate-jpamodelgen.version>
+		<hibernate-jpamodelgen.version>7.2.19.Final</hibernate-jpamodelgen.version>
 		<hypersistence-utils-71.version>3.15.3</hypersistence-utils-71.version>
 		<jsontypedef.version>0.2.2</jsontypedef.version>
 		<json-patch.version>1.13</json-patch.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
 		<testcontainers.version>2.0.5</testcontainers.version>
 		<mapstruct.version>1.6.3</mapstruct.version>
 		<jackson-databind-nullable.version>0.2.10</jackson-databind-nullable.version>
-		<postgresql.version>42.7.11</postgresql.version>
 		<sqlite-jdbc.version>3.53.2.0</sqlite-jdbc.version>
 		<hibernate-jpamodelgen.version>7.2.19.Final</hibernate-jpamodelgen.version>
 		<hypersistence-utils-71.version>3.15.3</hypersistence-utils-71.version>
@@ -46,8 +45,6 @@
 		<jsoup.version>1.22.2</jsoup.version>
 		<re2j.version>1.8</re2j.version>
 		<scim2-client.version>2.3.8</scim2-client.version>
-		<mockito.version>5.11.0</mockito.version>
-		<byte-buddy.version>1.14.12</byte-buddy.version>
 		<xmlunit.version>2.12.0</xmlunit.version>
 	</properties>
 


### PR DESCRIPTION
Bumps Spring Boot from `4.0.6` to `4.0.7` and `hibernate-jpamodelgen` from `7.2.12.Final` to `7.2.19.Final` (matching the BOM-managed Hibernate version).

Also removes stale version properties that are now superseded by the Spring Boot BOM:
- `postgresql.version` 42.7.11 — the BOM now manages the same version, so the pin is redundant
- `mockito.version` 5.11.0 and `byte-buddy.version` 1.14.12 — behind the BOM (5.20.0 / 1.17.8), but inert anyway since BOM imports don't honor property overrides; the BOM versions were already being resolved

Pins still ahead of the BOM (`httpclient5` 5.6.1, `commons-lang3` 3.20.0, `xmlunit-core` 2.12.0) and artifacts not managed by the BOM are kept. Verified with `mvn dependency:list` that the resolved dependency tree is identical before and after the property cleanup.